### PR TITLE
ci: remove unneeded bins and archives for release

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -111,6 +111,18 @@ jobs:
             ghcr.io/aquasecurity/trivy:canary
             public.ecr.aws/aquasecurity/trivy:canary
 
+      # size of `dist` dir for release is large
+      # we need to remove unneeded binaries and archives
+      # to avoid cases when cache will be removed due to size
+      - name: remove unneeded binaries and archives
+        if: ${{ inputs.goreleaser_config == 'goreleaser.yml' }}
+        run: |
+          ls -hl dist
+          rm -r dist/build-*
+          rm -r dist/*tar.gz
+          rm -r dist/*zip
+          ls -hl dist
+
       - name: Cache Trivy binaries
         uses: actions/cache@v3.3.1
         with:


### PR DESCRIPTION
## Description
`Dist` folder ща `goreleaser` is too large to be cached.
We can remove unneeded bins and archives before saving cache.
Then we will fix problem, when GitHub removes cache before we deploy deb and rpm packages.

## Checklist
- [ ] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [ ] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
