### PR TITLE
fix: test 2 [backport: release/v0.54]

### DIFF
--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -173,7 +173,7 @@ func testPBackport(s string, t *testing.T) {
 }
 
 func TestFlags(t *testing.T) {
-	testPBackport("pr1", t)
+	testPBackport("pr2", t)
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.54`:
 - [fix: test 2 (#71)](https://github.com/DmitriyLewen/trivy/pull/71)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)