### PR TITLE
fix: test 3 [backport: release/v0.54]

### DIFF
--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -173,7 +173,7 @@ func testPBackport(s string, t *testing.T) {
 }
 
 func TestFlags(t *testing.T) {
-	testPBackport("pr2", t)
+	testPBackport("pr3", t)
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.54`:
 - [fix: test 3 (#74)](https://github.com/DmitriyLewen/trivy/pull/74)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)