### PR TITLE
fix: test 1.1 [backport: release/v0.54]

### DIFF
--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -174,10 +174,14 @@ func testPBackport(s string, t *testing.T) {
 
 func TestFlags(t *testing.T) {
 <<<<<<< HEAD
+<<<<<<< HEAD
 	testPBackport("pr4", t)
 =======
 	testPBackport("pr7", t)
 >>>>>>> 39b35e181 (fix: test 7 (#81))
+=======
+	testBackport("pr1.1", t)
+>>>>>>> 56a91a40b (fix: test 1.1 (#84))
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.54`:
 - [fix: test 1.1 (#84)](https://github.com/DmitriyLewen/trivy/pull/84)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)