### PR TITLE
fix: test 2.1 [backport: release/v0.54]

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -64,6 +64,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // NewApp is the factory method to return Trivy CLI
 func NewApp() *cobra.Command {
+	fmt.Println("test2.1")
 	globalFlags := flag.NewGlobalFlagGroup()
 	rootCmd := NewRootCommand(globalFlags)
 	rootCmd.AddGroup(

--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -174,10 +174,14 @@ func testPBackport(s string, t *testing.T) {
 
 func TestFlags(t *testing.T) {
 <<<<<<< HEAD
+<<<<<<< HEAD
 	testPBackport("pr4", t)
 =======
 	testPBackport("pr7", t)
 >>>>>>> 39b35e181 (fix: test 7 (#81))
+=======
+	testBackport2("pr2.1", t)
+>>>>>>> 8b959dae1 (fix: test 2.1 (#87))
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.54`:
 - https://github.com/DmitriyLewen/trivy/pull/87

## ⚠️ Warning
Conflicts occurred during the cherry-pick and were force-committed without proper resolution. Please carefully review the changes, resolve any remaining conflicts, and ensure the code is in a valid state.