### PR TITLE
fix: test 2.4 [backport: release-backport-test]

### DIFF
--- a/pkg/commands/app_test.go
+++ b/pkg/commands/app_test.go
@@ -173,7 +173,11 @@ func testBackport2(s string, t *testing.T) {
 }
 
 func TestFlags(t *testing.T) {
+<<<<<<< HEAD
 	testBackport2("pr2.1", t)
+=======
+	testBackport3("pr2.4", t)
+>>>>>>> d3e1076de (fix: test 2.4 (#91))
 	type want struct {
 		format     types.Format
 		severities []dbTypes.Severity


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release-backport-test`:
 - https://github.com/DmitriyLewen/trivy/pull/91

## ⚠️ Warning
Conflicts occurred during the cherry-pick and were force-committed without proper resolution. Please carefully review the changes, resolve any remaining conflicts, and ensure the code is in a valid state.