### PR TITLE
refactor(purl): guard against empty package name in New

### DIFF
--- a/pkg/fanal/applier/docker.go
+++ b/pkg/fanal/applier/docker.go
@@ -275,13 +275,6 @@ func ApplyLayers(layers []ftypes.BlobInfo) ftypes.ArtifactDetail {
 }
 
 func newPURL(pkgType ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) *packageurl.PackageURL {
-	// Possible cases when package doesn't have name/version (e.g. local package.json).
-	// For these cases we don't need to create PURL, because this PURL will be incorrect.
-	// TODO Dmitriy - move to `purl` package
-	if pkg.Name == "" {
-		return nil
-	}
-
 	p, err := purl.New(pkgType, metadata, pkg)
 	if err != nil {
 		log.Error("Failed to create PackageURL", log.Err(err))

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -65,11 +65,13 @@ func FromString(s string) (*PackageURL, error) {
 
 // New builds a PackageURL from the given package and metadata.
 //
-// It returns (nil, nil) — without error — when the input cannot produce a
-// well-formed PURL, in particular:
-//   - the resolved package name is empty (e.g. local package.json without a
-//     name field, or a parser that strips the name);
-//   - the OCI metadata does not contain enough information to build a PURL.
+// It returns (nil, nil), without error, when the input cannot produce a
+// well-formed PURL. Concretely:
+//   - the resolved package name is empty: either pkg.Name is empty
+//     (e.g. a local package.json with no "name" field) or a parser
+//     strips it (parseGolang returns "" for local paths "./..." or "../...");
+//   - for OCI, parseOCI returns nil when metadata.RepoDigests is missing
+//     or unparseable.
 //
 // nolint: gocyclo
 func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*PackageURL, error) {
@@ -123,9 +125,10 @@ func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*Pac
 	case packageurl.TypeCocoapods:
 		name, subpath = parseCocoapods(name)
 	case packageurl.TypeOCI:
-		// OCI PURLs are derived from metadata, not pkg.Name, and several callers
-		// pass ftypes.Package{} here. The function returns from inside this case,
-		// so the empty-name guard at the bottom does not apply to OCI.
+		// OCI PURLs are built from metadata.RepoDigests and deliberately
+		// ignore pkg.Name (callers like pkg/sbom/io/encode.go pass an empty
+		// ftypes.Package{}). This case returns from the switch, so the
+		// empty-name guard at the bottom does not apply to OCI.
 		purl, err := parseOCI(metadata)
 		if err != nil {
 			return nil, err

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -63,6 +63,14 @@ func FromString(s string) (*PackageURL, error) {
 	return lo.ToPtr(PackageURL(p)), nil
 }
 
+// New builds a PackageURL from the given package and metadata.
+//
+// It returns (nil, nil) — without error — when the input cannot produce a
+// well-formed PURL, in particular:
+//   - the resolved package name is empty (e.g. local package.json without a
+//     name field, or a parser that strips the name);
+//   - the OCI metadata does not contain enough information to build a PURL.
+//
 // nolint: gocyclo
 func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*PackageURL, error) {
 	qualifiers := parseQualifier(pkg)
@@ -108,9 +116,6 @@ func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*Pac
 		namespace, name = parseComposer(name)
 	case packageurl.TypeGolang:
 		namespace, name = parseGolang(name)
-		if name == "" {
-			return nil, nil
-		}
 	case packageurl.TypeNPM:
 		namespace, name = parseNpm(name)
 	case packageurl.TypeSwift:
@@ -118,6 +123,9 @@ func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*Pac
 	case packageurl.TypeCocoapods:
 		name, subpath = parseCocoapods(name)
 	case packageurl.TypeOCI:
+		// OCI PURLs are derived from metadata, not pkg.Name, and several callers
+		// pass ftypes.Package{} here. The function returns from inside this case,
+		// so the empty-name guard at the bottom does not apply to OCI.
 		purl, err := parseOCI(metadata)
 		if err != nil {
 			return nil, err
@@ -129,6 +137,11 @@ func New(t ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) (*Pac
 		var qs packageurl.Qualifiers
 		namespace, name, qs = parseJulia(name, pkg.ID) // for Julia, the ID is set to the package UUID
 		qualifiers = append(qualifiers, qs...)
+	}
+
+	// A PURL without a name is malformed (e.g. local package.json with no name field).
+	if name == "" {
+		return nil, nil
 	}
 
 	return (*PackageURL)(packageurl.NewPackageURL(ptype, namespace, name, ver, qualifiers, subpath)), nil

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -526,6 +526,14 @@ func TestNewPackageURL(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty package name",
+			typ:  ftypes.NodePkg,
+			pkg: ftypes.Package{
+				Version: "1.0.0",
+			},
+			want: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/purl/purl_test.go
+++ b/pkg/purl/purl_test.go
@@ -534,6 +534,18 @@ func TestNewPackageURL(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			// parseMaven turns ":" into "/", which parsePkgName then splits
+			// into empty namespace and empty name; the bottom guard must
+			// catch this even though pkg.Name was not empty on entry.
+			name: "maven name parses to empty",
+			typ:  ftypes.Jar,
+			pkg: ftypes.Package{
+				Name:    ":",
+				Version: "1.0.0",
+			},
+			want: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/report/github/github_test.go
+++ b/pkg/report/github/github_test.go
@@ -233,6 +233,44 @@ func TestWriter_Write(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression: packages without a Name (e.g. a local package.json with
+			// no name field) used to produce a malformed PURL like `pkg:npm/@1.0.0`.
+			// buildPurl must now emit an empty PackageUrl instead.
+			name: "package without name produces empty PURL",
+			report: types.Report{
+				SchemaVersion: 2,
+				ArtifactName:  "package-lock.json",
+				Results: types.Results{
+					{
+						Target: "package-lock.json",
+						Class:  "lang-pkgs",
+						Type:   "npm",
+						Packages: []ftypes.Package{
+							{
+								Version:      "1.0.0",
+								Relationship: ftypes.RelationshipDirect,
+							},
+						},
+					},
+				},
+			},
+			want: map[string]github.Manifest{
+				"package-lock.json": {
+					Name: "npm",
+					File: &github.File{
+						SrcLocation: "package-lock.json",
+					},
+					Resolved: map[string]github.Package{
+						"": {
+							PackageUrl:   "",
+							Relationship: "direct",
+							Scope:        "runtime",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Follow-up to review feedback in #10298: move the `pkg.Name == ""` guard from `pkg/fanal/applier/docker.go::newPURL` into `purl.New` so the safety check is centralized and applied for all callers. The TODO `move to "purl" package` in `applier/docker.go` is removed.

OCI is unaffected — it returns earlier inside the switch (OCI PURLs are derived from `metadata.RepoDigests` and deliberately ignore `pkg.Name`).

### Latent bug fix in `pkg/report/github/github.go::buildPurl`
Previously a package with empty `Name` produced a malformed PURL like `pkg:npm/@1.0.0` and slipped past the `packageUrl == nil` check. Now `buildPurl` correctly returns `""`. A regression test in `pkg/report/github/github_test.go` covers this.

### Changes
- `pkg/purl/purl.go`: add the `if name == ""` guard after the type-switch; document the `(nil, nil)` contract on `New`; expand the OCI-case comment; drop the redundant `if name == ""` from the Golang case (now covered by the shared guard).
- `pkg/fanal/applier/docker.go`: remove the duplicated guard and stale TODO from `newPURL`; the function stays as the local error+log wrapper.
- `pkg/purl/purl_test.go`: add two cases — `pkg.Name == ""` and a Maven name that parses to empty.
- `pkg/report/github/github_test.go`: regression case for an unnamed npm package.

## Related issues

N/A — follow-up to a review comment.

## Related PRs
- [ ] #10298

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).