### PR TITLE
fix: surface the original analysis error instead of context cancellation

### DIFF
--- a/pkg/fanal/artifact/image/image.go
+++ b/pkg/fanal/artifact/image/image.go
@@ -465,8 +465,9 @@ func (a Artifact) inspectLayer(ctx context.Context, layer types.Layer, disabled 
 	defer composite.Cleanup()
 
 	// Walk a tar layer
+	var analyzeErr error
 	opqDirs, whFiles, err := a.walker.Walk(cr, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
-		if err = a.analyzer.AnalyzeFile(egCtx, eg, limit, result, "", filePath, info, opener, disabled, opts); err != nil {
+		if err := a.analyzer.AnalyzeFile(egCtx, eg, limit, result, "", filePath, info, opener, disabled, opts); err != nil {
 			return xerrors.Errorf("failed to analyze %s: %w", filePath, err)
 		}
 
@@ -488,12 +489,17 @@ func (a Artifact) inspectLayer(ctx context.Context, layer types.Layer, disabled 
 		return nil
 	})
 	if err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("walk error: %w", err)
+		analyzeErr = xerrors.Errorf("walk error: %w", err)
 	}
 
-	// Wait for all the goroutine to finish and check errors
+	// errgroup cancels egCtx when an analysis goroutine fails, so the walk above can
+	// fail with context.Canceled and mask the real cause (e.g. a remote 429).
+	// Surface eg.Wait()'s error first; fall back to the walk error only when the group is clean.
 	if err = eg.Wait(); err != nil {
 		return types.BlobInfo{}, xerrors.Errorf("analyze error: %w", err)
+	}
+	if analyzeErr != nil {
+		return types.BlobInfo{}, analyzeErr
 	}
 
 	// Post-analysis

--- a/pkg/fanal/artifact/local/fs.go
+++ b/pkg/fanal/artifact/local/fs.go
@@ -212,22 +212,28 @@ func (a Artifact) Inspect(ctx context.Context) (artifact.Reference, error) {
 
 	// Use static paths instead of traversing the filesystem when all analyzers implement StaticPathAnalyzer
 	// so that we can analyze files faster
+	var analyzeErr error
 	if paths, canUseStaticPaths := a.analyzer.StaticPaths(a.artifactOption.DisabledAnalyzers); canUseStaticPaths {
 		// Analyze files in static paths
 		a.logger.Debug("Analyzing files in static paths")
 		if err = a.analyzeWithStaticPaths(egCtx, eg, limit, result, composite, opts, paths); err != nil {
-			return artifact.Reference{}, xerrors.Errorf("analyze with static paths: %w", err)
+			analyzeErr = xerrors.Errorf("analyze with static paths: %w", err)
 		}
 	} else {
 		// Analyze files by traversing the root directory
 		if err = a.analyzeWithRootDir(egCtx, eg, limit, result, composite, opts); err != nil {
-			return artifact.Reference{}, xerrors.Errorf("analyze with traversal: %w", err)
+			analyzeErr = xerrors.Errorf("analyze with traversal: %w", err)
 		}
 	}
 
-	// Wait for all the goroutine to finish.
+	// errgroup cancels egCtx when an analysis goroutine fails, so the walk above can
+	// fail with context.Canceled and mask the real cause (e.g. a remote 429).
+	// Surface eg.Wait()'s error first; fall back to the walk error only when the group is clean.
 	if err = eg.Wait(); err != nil {
 		return artifact.Reference{}, xerrors.Errorf("analyze error: %w", err)
+	}
+	if analyzeErr != nil {
+		return artifact.Reference{}, analyzeErr
 	}
 
 	// Post-analysis

--- a/pkg/fanal/artifact/local/fs_test.go
+++ b/pkg/fanal/artifact/local/fs_test.go
@@ -1,8 +1,11 @@
 package local
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +18,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 	"github.com/aquasecurity/trivy/pkg/misconf"
+	trivytypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/uuid"
 
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/config/all"
@@ -2662,4 +2666,41 @@ func Test_sanitizeRemoteURL(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// userErrorAnalyzer fails every matching file with a *types.UserError,
+// emulating a fatal analyzer error such as a remote Maven 429.
+type userErrorAnalyzer struct{}
+
+func (userErrorAnalyzer) Type() analyzer.Type { return "user-error-test" }
+func (userErrorAnalyzer) Version() int        { return 1 }
+func (userErrorAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	return strings.HasSuffix(filePath, ".usererror")
+}
+
+func (userErrorAnalyzer) Analyze(_ context.Context, _ analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	return nil, &trivytypes.UserError{Message: "429 Too Many Requests"}
+}
+
+// TestArtifact_Inspect_AnalyzeErrorNotMasked is a regression test for #10790:
+// a fatal analyzer error (a remote Maven 429, as *types.UserError) must be
+// surfaced, not masked by the context.Canceled the walk hits after egCtx cancels.
+func TestArtifact_Inspect_AnalyzeErrorNotMasked(t *testing.T) {
+	dir := t.TempDir()
+	// Parallel=1 with several files: the first file cancels egCtx, so a later
+	// file's semaphore acquire fails with context.Canceled.
+	for i := 0; i < 10; i++ {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, fmt.Sprintf("%d.usererror", i)), []byte("x"), 0o600))
+	}
+
+	analyzer.RegisterAnalyzer(userErrorAnalyzer{})
+	t.Cleanup(func() { analyzer.DeregisterAnalyzer("user-error-test") })
+
+	a, err := NewArtifact(dir, cache.NewMemoryCache(), walker.NewFS(), artifact.Option{Parallel: 1})
+	require.NoError(t, err)
+
+	_, err = a.Inspect(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "429 Too Many Requests")
 }

--- a/pkg/fanal/artifact/vm/vm.go
+++ b/pkg/fanal/artifact/vm/vm.go
@@ -102,9 +102,10 @@ func (a *Storage) Analyze(ctx context.Context, r *io.SectionReader) (types.BlobI
 	defer composite.Cleanup()
 
 	// TODO: Always walk from the root directory. Consider whether there is a need to be able to set optional
+	var analyzeErr error
 	err = a.walker.Walk(r, "/", a.artifactOption.WalkerOption, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
 		path := strings.TrimPrefix(filePath, "/")
-		if err = a.analyzer.AnalyzeFile(egCtx, eg, limit, result, "/", path, info, opener, nil, opts); err != nil {
+		if err := a.analyzer.AnalyzeFile(egCtx, eg, limit, result, "/", path, info, opener, nil, opts); err != nil {
 			return xerrors.Errorf("analyze file (%s): %w", path, err)
 		}
 
@@ -127,12 +128,17 @@ func (a *Storage) Analyze(ctx context.Context, r *io.SectionReader) (types.BlobI
 		return nil
 	})
 	if err != nil {
-		return types.BlobInfo{}, xerrors.Errorf("walk vm error: %w", err)
+		analyzeErr = xerrors.Errorf("walk vm error: %w", err)
 	}
 
-	// Wait for all the goroutine to finish.
+	// errgroup cancels egCtx when an analysis goroutine fails, so the walk above can
+	// fail with context.Canceled and mask the real cause (e.g. a remote 429).
+	// Surface eg.Wait()'s error first; fall back to the walk error only when the group is clean.
 	if err = eg.Wait(); err != nil {
 		return types.BlobInfo{}, xerrors.Errorf("analyze error: %w", err)
+	}
+	if analyzeErr != nil {
+		return types.BlobInfo{}, analyzeErr
 	}
 
 	// Post-analysis


### PR DESCRIPTION

## Description

When an analyzer fails with a fatal error during artifact analysis, the user could see a generic `context canceled` instead of the real cause.

`Artifact.Inspect` / `inspectLayer` / VM `Analyze` run file analysis through `errgroup.WithContext`. The synchronous file walk uses the group's `egCtx` for `limit.Acquire`. When one analysis goroutine returns an error, `errgroup` cancels `egCtx`; the still-running walk then fails its next `Acquire` with `context.Canceled`, and that walk error was returned **before** `eg.Wait()` — which is where the original error actually lives.

This regression was latent since the `sync.WaitGroup` → `errgroup.WithContext` migration (#9538) and became observable once #10693 made the Maven `pom` analyzer return a `*types.UserError` on a remote `429 Too Many Requests`. It only reproduces on large/multi-module trees (e.g. Keycloak), where the walk is still in progress when the 429 fires — a single-`pom.xml` project surfaces the 429 correctly because the walk finishes first.

The fix: always wait for the analysis goroutines first so `eg.Wait()` surfaces the original error, and only fall back to the walk error when the goroutines finished cleanly. Applied consistently to the `local` (fs), `image` and `vm` artifacts.

Note: in the masking scenario the user now sees `analyze error: <real cause>` instead of `... semaphore acquire: context canceled`. This is the intended change; no code depends on the old error text.

Reproduced by scanning the [Keycloak](https://github.com/keycloak/keycloak) repository (186 `pom.xml` files) with an empty `~/.m2` while Maven Central rate-limits the IP.

### Before

```console
$ trivy fs --scanners vuln .
2026-06-04T14:53:48+03:00	INFO	[vuln] Vulnerability scanning is enabled
2026-06-04T14:53:49+03:00	FATAL	Fatal error	run error: fs scan error: scan error: scan failed: failed analysis: analyze with traversal: walk dir error: unknown error with adapters/saml/wildfly/wildfly-subsystem/pom.xml: failed to analyze file: analyze file (adapters/saml/wildfly/wildfly-subsystem/pom.xml): semaphore acquire: context canceled
```

The actual 429 is invisible; the user only sees `context canceled`, and the reported file is arbitrary (depends on timing).

### After

```console
$ trivy fs --scanners vuln .
2026-06-04T14:53:49+03:00	INFO	[vuln] Vulnerability scanning is enabled
2026-06-04T14:53:50+03:00	FATAL	Error	remote Maven repository returned 429 Too Many Requests for https://repo.maven.apache.org/maven2/org/infinispan/infinispan-bom/16.0.8/infinispan-bom-16.0.8.pom. Retry-After: 694.
The repository blocks all subsequent requests from this IP until the block clears.
To avoid this, populate the local Maven cache before scanning (e.g. run `mvn dependency:resolve` and cache ~/.m2 in CI).
```

## Related issues
- Close #10792

## Related PRs
- #10693 (introduced the `*types.UserError` that exposed this)

## Checklist
- [x] I've read the [guidelines for contributing](https://trivy.dev/docs/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://trivy.dev/docs/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
